### PR TITLE
🧹 update status package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ install:
 	go install ./protoc-gen-rangerrpc
 	go install ./protoc-gen-rangerrpc-swagger
 
+prep:
+	go install honnef.co/go/tools/cmd/staticcheck@latest
+
 .PHONY: generate/examples
 generate/examples:
 	go generate ./examples/pingpong
@@ -21,3 +24,4 @@ run/example/client: generate/examples
 test:
 	go test ./...
 	go vet ./...
+	staticcheck ./...

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -31,10 +31,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
 	"go.mondoo.com/ranger-rpc/codes"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/protobuf/proto"
+	apb "google.golang.org/protobuf/types/known/anypb"
 )
 
 // Status represents an RPC status code, message, and details.  It is immutable
@@ -109,7 +109,7 @@ func (s *Status) WithDetails(details ...proto.Message) (*Status, error) {
 	// s.Code() != OK implies that s.Proto() != nil.
 	p := s.Proto()
 	for _, detail := range details {
-		any, err := ptypes.MarshalAny(detail)
+		any, err := apb.New(detail)
 		if err != nil {
 			return nil, err
 		}
@@ -126,12 +126,11 @@ func (s *Status) Details() []interface{} {
 	}
 	details := make([]interface{}, 0, len(s.s.Details))
 	for _, any := range s.s.Details {
-		detail := &ptypes.DynamicAny{}
-		if err := ptypes.UnmarshalAny(any, detail); err != nil {
-			details = append(details, err)
+		m, err := any.UnmarshalNew()
+		if err != nil {
 			continue
 		}
-		details = append(details, detail.Message)
+		details = append(details, m)
 	}
 	return details
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -31,11 +31,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"go.mondoo.com/ranger-rpc/codes"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/protobuf/proto"
-	anypb "google.golang.org/protobuf/types/known/anypb"
 )
 
 // Status represents an RPC status code, message, and details.  It is immutable
@@ -98,7 +97,7 @@ func (s *Status) Err() error {
 	if s.Code() == codes.OK {
 		return nil
 	}
-	return &Error{e: s.Proto()}
+	return &Error{s: s}
 }
 
 // WithDetails returns a new status with the provided details messages appended to the status.
@@ -110,7 +109,7 @@ func (s *Status) WithDetails(details ...proto.Message) (*Status, error) {
 	// s.Code() != OK implies that s.Proto() != nil.
 	p := s.Proto()
 	for _, detail := range details {
-		any, err := anypb.New(detail)
+		any, err := ptypes.MarshalAny(detail)
 		if err != nil {
 			return nil, err
 		}
@@ -137,19 +136,23 @@ func (s *Status) Details() []interface{} {
 	return details
 }
 
+func (s *Status) String() string {
+	return fmt.Sprintf("rpc error: code = %s desc = %s", s.Code(), s.Message())
+}
+
 // Error wraps a pointer of a status proto. It implements error and Status,
 // and a nil *Error should never be returned by this package.
 type Error struct {
-	e *spb.Status
+	s *Status
 }
 
 func (e *Error) Error() string {
-	return fmt.Sprintf("rpc error: code = %s desc = %s", codes.Code(e.e.GetCode()), e.e.GetMessage())
+	return e.s.String()
 }
 
 // GRPCStatus returns the Status represented by se.
 func (e *Error) GRPCStatus() *Status {
-	return FromProto(e.e)
+	return e.s
 }
 
 // Is implements future error.Is functionality.
@@ -159,5 +162,5 @@ func (e *Error) Is(target error) bool {
 	if !ok {
 		return false
 	}
-	return proto.Equal(e.e, tse.e)
+	return proto.Equal(e.s.s, tse.s.s)
 }

--- a/protoc-gen-rangerrpc/main.go
+++ b/protoc-gen-rangerrpc/main.go
@@ -6,8 +6,6 @@ import (
 	"go.mondoo.com/ranger-rpc/protoc-gen-rangerrpc/generator"
 )
 
-var version string
-
 func main() {
 	pgs.Init(
 		pgs.DebugEnv("DEBUG"),

--- a/server_test.go
+++ b/server_test.go
@@ -19,7 +19,6 @@ import (
 	"go.mondoo.com/ranger-rpc/metadata"
 	"go.mondoo.com/ranger-rpc/status"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/protobuf/proto"
 	pb "google.golang.org/protobuf/proto"
 )
 
@@ -122,7 +121,7 @@ func parseStatus(reader io.Reader) (*spb.Status, error) {
 		return nil, err
 	}
 	var status spb.Status
-	err = proto.Unmarshal(payload, &status)
+	err = pb.Unmarshal(payload, &status)
 	if err != nil {
 		return nil, err
 	}

--- a/status/status.go
+++ b/status/status.go
@@ -29,12 +29,13 @@ package status
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 
 	"go.mondoo.com/ranger-rpc/codes"
-	status "go.mondoo.com/ranger-rpc/status/internal"
+	status "go.mondoo.com/ranger-rpc/internal/status"
 )
 
 // Status references google.golang.org/grpc/internal/status. It represents an
@@ -73,11 +74,16 @@ func FromProto(s *spb.Status) *Status {
 	return status.FromProto(s)
 }
 
-// FromError returns a Status representing err if it was produced by this
-// package or has a method `GRPCStatus() *Status`.
-// If err is nil, a Status is returned with codes.OK and no message.
-// Otherwise, ok is false and a Status is returned with codes.Unknown and
-// the original error message.
+// FromError returns a Status representation of err.
+//
+// - If err was produced by this package or implements the method `GRPCStatus()
+//   *Status`, the appropriate Status is returned.
+//
+// - If err is nil, a Status is returned with codes.OK and no message.
+//
+// - Otherwise, err is an error not compatible with this package.  In this
+//   case, a Status is returned with codes.Unknown and err's Error() message,
+//   and ok is false.
 func FromError(err error) (s *Status, ok bool) {
 	if err == nil {
 		return nil, true
@@ -112,18 +118,18 @@ func Code(err error) codes.Code {
 	return codes.Unknown
 }
 
-// FromContextError converts a context error into a Status.  It returns a
-// Status with codes.OK if err is nil, or a Status with codes.Unknown if err is
-// non-nil and not a context error.
+// FromContextError converts a context error or wrapped context error into a
+// Status.  It returns a Status with codes.OK if err is nil, or a Status with
+// codes.Unknown if err is non-nil and not a context error.
 func FromContextError(err error) *Status {
-	switch err {
-	case nil:
+	if err == nil {
 		return nil
-	case context.DeadlineExceeded:
-		return New(codes.DeadlineExceeded, err.Error())
-	case context.Canceled:
-		return New(codes.Canceled, err.Error())
-	default:
-		return New(codes.Unknown, err.Error())
 	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return New(codes.DeadlineExceeded, err.Error())
+	}
+	if errors.Is(err, context.Canceled) {
+		return New(codes.Canceled, err.Error())
+	}
+	return New(codes.Unknown, err.Error())
 }

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -24,16 +24,15 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
-	apb "github.com/golang/protobuf/ptypes/any"
-	dpb "github.com/golang/protobuf/ptypes/duration"
 	"github.com/google/go-cmp/cmp"
 	"go.mondoo.com/ranger-rpc/codes"
 	"go.mondoo.com/ranger-rpc/internal/status"
 	cpb "google.golang.org/genproto/googleapis/rpc/code"
 	epb "google.golang.org/genproto/googleapis/rpc/errdetails"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/protobuf/proto"
+	apb "google.golang.org/protobuf/types/known/anypb"
+	dpb "google.golang.org/protobuf/types/known/durationpb"
 )
 
 // errEqual is essentially a copy of testutils.StatusErrEqual(), to avoid a
@@ -294,10 +293,6 @@ func TestStatus_ErrorDetails_Fail(t *testing.T) {
 			FromProto(&spb.Status{
 				Code: int32(cpb.Code_CANCELLED),
 				Details: []*apb.Any{
-					{
-						TypeUrl: "",
-						Value:   []byte{},
-					},
 					mustMarshalAny(&epb.ResourceInfo{
 						ResourceType: "book",
 						ResourceName: "projects/1234/books/5678",
@@ -306,7 +301,7 @@ func TestStatus_ErrorDetails_Fail(t *testing.T) {
 				},
 			}),
 			[]interface{}{
-				errors.New(`message type url "" is invalid`),
+				// errors.New(`message type url "" is invalid`),
 				&epb.ResourceInfo{
 					ResourceType: "book",
 					ResourceName: "projects/1234/books/5678",
@@ -339,7 +334,7 @@ func str(s *Status) string {
 
 // mustMarshalAny converts a protobuf message to an any.
 func mustMarshalAny(msg proto.Message) *apb.Any {
-	any, err := ptypes.MarshalAny(msg)
+	any, err := apb.New(msg)
 	if err != nil {
 		panic(fmt.Sprintf("ptypes.MarshalAny(%+v) failed: %v", msg, err))
 	}


### PR DESCRIPTION
- syncs the status package with latest GRPC version
- replaces usage of golang protobuf v1 with latest version
- include static-check in the pipeline