### PR TITLE
🧹 use DefaultServeMux in example 

### DIFF
--- a/examples/pingpong/server/main.go
+++ b/examples/pingpong/server/main.go
@@ -11,14 +11,14 @@ func main() {
 	fmt.Println("start pingpong example server")
 
 	// init service implementation and attach it to the standard mux router for the /api/ prefix
-	mux := http.NewServeMux()
+	mux := http.DefaultServeMux
 	p := &pingpong.PingPongServiceImpl{}
 	mux.Handle("/api/", http.StripPrefix("/api", pingpong.NewPingPongServer(p)))
 
 	// start the server on port 2155
 	port := 2155
 	fmt.Printf("listen on :%d\n", port)
-	err := http.ListenAndServe(fmt.Sprintf(":%d", port), mux)
+	err := http.ListenAndServe(fmt.Sprintf("localhost:%d", port), nil)
 	if err != nil {
 		fmt.Println("was not able to start the server")
 		panic(err)


### PR DESCRIPTION
we use DefaultServeMux to benefit from default additions like profiler

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>