### PR TITLE
⭐️ ability to print curl command when trace is active

### DIFF
--- a/examples/pingpong/client/main.go
+++ b/examples/pingpong/client/main.go
@@ -6,10 +6,12 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/rs/zerolog"
 	"go.mondoo.com/ranger-rpc/examples/pingpong"
 )
 
 func main() {
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
 	fmt.Println("start pingpong example client")
 	client, err := pingpong.NewPingPongClient("http://localhost:2155/api/", &http.Client{
 		Timeout: time.Second * 10,

--- a/go.mod
+++ b/go.mod
@@ -37,4 +37,5 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	moul.io/http2curl v1.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -738,6 +738,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+moul.io/http2curl v1.0.0 h1:6XwpyZOYsgZJrU8exnG87ncVkU1FVCcTRpwzOkTDUi8=
+moul.io/http2curl v1.0.0/go.mod h1:f6cULg+e4Md/oW1cYmwW4IWQOVl2lGbmCNGOHvzX2kE=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=


### PR DESCRIPTION
if the trace logger is activated, it prints out a curl command for easier debugging:

```bash
$ make run/example/client
go generate ./examples/pingpong
go generate ./examples/oneof
go generate ./examples/swagger
go run examples/pingpong/client/main.go
start pingpong example client
call server ping
{"level":"trace","time":"2022-07-25T16:38:50+02:00","message":"curl -X 'POST' -d '{\"sender\":\"bob\"}' -H 'Accept: application/json' -H 'Content-Length: 16' -H 'Content-Type: application/json' 'http://localhost:2155/api/PingPong/Ping'"}
server ping response: Hello bob
```

This can then be run separately for debugging

```bash
$ curl -X 'POST' -d '{"sender":"bob"}' -H 'Accept: application/json' -H 'Content-Length: 16' -H 'Content-Type: application/json' 'http://localhost:2155/api/PingPong/Ping'
{"message":"Hello bob"}%      
```

The generated curl command does not use the protobuf marshalling / unmarshalling, but it allows you to quickly see input / output issues.