### PR TITLE
⭐️ add default http client

### DIFF
--- a/httpclient.go
+++ b/httpclient.go
@@ -1,0 +1,33 @@
+package ranger
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+var (
+	DefaultHttpTimeout         = 30 * time.Second
+	DefaultIdleConnTimeout     = 30 * time.Second
+	DefaultTLSHandshakeTimeout = 10 * time.Second
+)
+
+func DefaultHttpClient() *http.Client {
+	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   DefaultHttpTimeout,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       DefaultIdleConnTimeout,
+		TLSHandshakeTimeout:   DefaultTLSHandshakeTimeout,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	httpClient := &http.Client{
+		Transport: tr,
+		Timeout:   DefaultHttpTimeout,
+	}
+	return httpClient
+}


### PR DESCRIPTION
This allows clients to use more security defaults. Instead of using own defaults like:

```go
client, err := pingpong.NewPingPongClient("http://localhost:2155/api/", &http.Client{
  Timeout: time.Second * 10,
})
```

you can now define:

```go
client, err := pingpong.NewPingPongClient("http://localhost:2155/api/", &ranger.DefaultHttpClient())
```