### PR TITLE
⭐️ allow users to add multiple plugins at once

### DIFF
--- a/client.go
+++ b/client.go
@@ -26,8 +26,10 @@ type Client struct {
 	plugins []ClientPlugin
 }
 
-func (c *Client) AddPlugin(plugin ClientPlugin) {
-	c.plugins = append(c.plugins, plugin)
+func (c *Client) AddPlugin(plugins ...ClientPlugin) {
+	for i := range plugins {
+		c.plugins = append(c.plugins, plugins[i])
+	}
 }
 
 type HTTPClient interface {


### PR DESCRIPTION
When users want to attach multiple clients to a generated client, they needed to write the following over and over:

```go

var plugins []ranger.ClientPlugin

client, err := NewMyServiceClient(url, ranger.DefaultHttpClient())
if err != nil {
	return nil, err
}

for i := range plugins {
	client.AddPlugin(plugins[i])
}
```

with this change its easier and users can simply write:

```
client, err := NewMyServiceClient(url, ranger.DefaultHttpClient())
if err != nil {
	return nil, err
}
client.AddPlugin(plugins)
```

