### PR TITLE
⭐️ request scope plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cockroachdb/errors v1.9.0
 	github.com/go-openapi/spec v0.20.6
 	github.com/google/go-cmp v0.5.8
+	github.com/google/uuid v1.3.0
 	github.com/lyft/protoc-gen-star v0.6.1
 	github.com/rs/zerolog v1.27.0
 	github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,8 @@ github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=

--- a/plugins/scope/request_scope.go
+++ b/plugins/scope/request_scope.go
@@ -1,0 +1,49 @@
+package scope
+
+import (
+	"net/http"
+
+	"github.com/google/uuid"
+	"go.mondoo.com/ranger-rpc"
+)
+
+const XRequestID = "X-Request-ID"
+
+type RequestIdOption func(s *requestIdPlugin)
+
+func WithUuid(requestId string) RequestIdOption {
+	return func(s *requestIdPlugin) {
+		s.requestID = requestId
+	}
+}
+
+// NewRequestIDPlugin creates a RangerPlugin that adds the
+// X-Request-ID header to outgoing requests. All RPCs
+// that share the same RangerPlugin will get the same ID
+func NewRequestIDRangerPlugin(opts ...RequestIdOption) ranger.ClientPlugin {
+	p := &requestIdPlugin{}
+
+	for i := range opts {
+		opts[i](p)
+	}
+
+	if p.requestID == "" {
+		p.requestID = uuid.New().String()
+	}
+
+	return p
+}
+
+type requestIdPlugin struct {
+	requestID string
+}
+
+func (p *requestIdPlugin) GetName() string {
+	return "Request Scope Plugin"
+}
+
+func (p *requestIdPlugin) GetHeader(data []byte) http.Header {
+	header := make(http.Header)
+	header.Set(XRequestID, p.requestID)
+	return header
+}

--- a/plugins/scope/request_scope_test.go
+++ b/plugins/scope/request_scope_test.go
@@ -1,0 +1,40 @@
+package scope
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestScopePlugin(t *testing.T) {
+	t.Run("header is valid uuid", func(t *testing.T) {
+		p := NewRequestIDRangerPlugin()
+		header := p.GetHeader(nil)
+		headerValue := header.Get(XRequestID)
+		require.NotEmpty(t, headerValue)
+		_, err := uuid.Parse(headerValue)
+		require.NoError(t, err)
+	})
+
+	t.Run("multiple calls produce the same value", func(t *testing.T) {
+		p := NewRequestIDRangerPlugin()
+		headerValue1 := p.GetHeader(nil).Get(XRequestID)
+		headerValue2 := p.GetHeader(nil).Get(XRequestID)
+		require.Equal(t, headerValue1, headerValue2)
+	})
+
+	t.Run("uniqueness", func(t *testing.T) {
+		p1 := NewRequestIDRangerPlugin()
+		p2 := NewRequestIDRangerPlugin()
+		headerValue1 := p1.GetHeader(nil).Get(XRequestID)
+		headerValue2 := p2.GetHeader(nil).Get(XRequestID)
+		require.NotEqual(t, headerValue1, headerValue2)
+	})
+
+	t.Run("custom uuid", func(t *testing.T) {
+		p1 := NewRequestIDRangerPlugin(WithUuid("custom-uuid"))
+		headerValue1 := p1.GetHeader(nil).Get(XRequestID)
+		require.Equal(t, "custom-uuid", headerValue1)
+	})
+}


### PR DESCRIPTION
This change provides a ranger plugin that allows an easy way to add anonymous request id header