### PR TITLE
⭐️ new xinfoheader plugin

### DIFF
--- a/plugins/scope/info.go
+++ b/plugins/scope/info.go
@@ -1,0 +1,74 @@
+package scope
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+
+	"go.mondoo.com/ranger-rpc"
+)
+
+func NewCustomHeaderRangerPlugin(header http.Header) ranger.ClientPlugin {
+	return &customHeaderPlugin{
+		header: header,
+	}
+}
+
+type customHeaderPlugin struct {
+	header http.Header
+}
+
+func (u *customHeaderPlugin) GetName() string {
+	return "Custom Header Plugin"
+}
+
+func (u *customHeaderPlugin) GetHeader(data []byte) http.Header {
+	return u.header
+}
+
+// sanitizeString takes an input and prepares it for use in User-Client header
+func sanitizeString(k string) string {
+	return strings.ReplaceAll(k, " ", "-")
+}
+
+// XInfoHeader encodes key/value pairs to a string that can be used as a HTTP header.
+// The keys and values are sanitized to be used as HTTP header values. All spaces in
+// keys and values are replaced with dashes.
+func XInfoHeader(keyValuePairs map[string]string) string {
+	if len(keyValuePairs) == 0 {
+		return ""
+	}
+
+	keys := make([]string, 0, len(keyValuePairs))
+	for k := range keyValuePairs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var buf bytes.Buffer
+	for i := range keys {
+		buf.WriteByte(' ')
+		buf.WriteString(sanitizeString(keys[i]))
+		buf.WriteByte('/')
+		buf.WriteString(sanitizeString(keyValuePairs[keys[i]]))
+	}
+	// remove first whitespace on first entry
+	return buf.String()[1:]
+}
+
+func ParseXInfoHeader(value string) (map[string]string, error) {
+	res := make(map[string]string)
+	entries := strings.Split(value, " ")
+	for i := range entries {
+		key_value := strings.SplitN(entries[i], "/", 2)
+		if len(key_value) != 2 {
+			return nil, errors.New("invalid info header")
+		}
+		key := key_value[0]
+		value := key_value[1]
+		res[key] = value
+	}
+	return res, nil
+}

--- a/plugins/scope/info_test.go
+++ b/plugins/scope/info_test.go
@@ -1,0 +1,45 @@
+package scope
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomHeaderRangerPlugin(t *testing.T) {
+	expected := map[string]string{
+		"version": "1.1.4",
+		"build":   "abc",
+	}
+
+	h := http.Header{}
+	h.Set("X-Info", XInfoHeader(expected))
+
+	userAgent := NewCustomHeaderRangerPlugin(h)
+	pluginHeader := userAgent.GetHeader(nil)
+	xinfoHeader := pluginHeader.Get("X-Info")
+	assert.Equal(t, "build/abc version/1.1.4", xinfoHeader)
+
+	value, err := ParseXInfoHeader(xinfoHeader)
+	require.NoError(t, err)
+	assert.Equal(t, expected, value)
+}
+
+func TestXInfoHeader(t *testing.T) {
+	for _, test := range []struct {
+		kv       map[string]string
+		expected string
+	}{
+		{nil, ""},
+		{map[string]string{"abc": "123"}, "abc/123"},
+		{map[string]string{"abc": "123", "xyz": "567", "boo": ""}, "abc/123 boo/ xyz/567"},
+		{map[string]string{"a b c": "1 2 3"}, "a-b-c/1-2-3"}, // spaces are replaced with dashes
+	} {
+		got := XInfoHeader(test.kv)
+		if got != test.expected {
+			t.Errorf("header(%q) = %q, want %q", test.kv, got, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
- the new `NewCustomHeaderRangerPlugin` adds a new ranger plugin that allows you to add custom headers to all requests
- to properly generate a `XInfoHeader` it provides the helper functions to turn a map[string]string into a string that can be used in a http header

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>