### PR TITLE
⭐️ manual client creation (with proxy)

### DIFF
--- a/httpclient.go
+++ b/httpclient.go
@@ -3,7 +3,10 @@ package ranger
 import (
 	"net"
 	"net/http"
+	"net/url"
 	"time"
+
+	"github.com/rs/zerolog/log"
 )
 
 var (
@@ -12,9 +15,13 @@ var (
 	DefaultTLSHandshakeTimeout = 10 * time.Second
 )
 
-func DefaultHttpClient() *http.Client {
+func newHttpTransport(proxy string) (*http.Transport, error) {
+	proxyFn, err := newProxyFunc(proxy)
+	if err != nil {
+		return nil, err
+	}
 	tr := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy: proxyFn,
 		DialContext: (&net.Dialer{
 			Timeout:   DefaultHttpTimeout,
 			KeepAlive: 30 * time.Second,
@@ -25,9 +32,60 @@ func DefaultHttpClient() *http.Client {
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 
-	httpClient := &http.Client{
+	return tr, nil
+}
+
+func newHttpClient(tr *http.Transport) *http.Client {
+	return &http.Client{
 		Transport: tr,
 		Timeout:   DefaultHttpTimeout,
 	}
-	return httpClient
+}
+
+// DefaultHttpClient will set up a basic client
+// with default timeouts/proxies/etc.
+func DefaultHttpClient() *http.Client {
+	tr, err := newHttpTransport("")
+	if err != nil {
+		log.Fatal().Err(err).Msg("unexpectedly failed to create a default HttpClient")
+	}
+
+	return newHttpClient(tr)
+}
+
+type HttpClientOpts struct {
+	// Proxy is the string representation of the proxy the client
+	// should use for connections.
+	Proxy string
+}
+
+func HttpClient(opts *HttpClientOpts) (*http.Client, error) {
+	tr, err := newHttpTransport(opts.Proxy)
+	if err != nil {
+		return nil, err
+	}
+
+	return newHttpClient(tr), nil
+}
+
+type proxyFunc func(*http.Request) (*url.URL, error)
+
+// newProxyFunc will use a standard ProxyFromEnvironment if no proxy
+// information is provided. Otherwise, parse the proxy string, and use
+// it as the proxy endpoint.
+func newProxyFunc(proxy string) (proxyFunc, error) {
+	proxyFn := http.ProxyFromEnvironment
+
+	if proxy != "" {
+		proxyURL, err := url.Parse(proxy)
+		if err != nil {
+			return nil, err
+		}
+
+		proxyFn = func(*http.Request) (*url.URL, error) {
+			return proxyURL, nil
+		}
+	}
+
+	return proxyFn, nil
 }


### PR DESCRIPTION
Keep DefaultHttpClient() the way it is, but introduce a new HttpClient() that will allow specifying non-default values for the client.

Specifically, allow passing in a proxy string that will used for connections.