### PR TITLE
🔒 Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,9 +1,19 @@
 name: "CLA Assistant & License Check"
+# SECURITY: This workflow uses pull_request_target and issue_comment, which run
+# with a write-scoped GITHUB_TOKEN and access to repo secrets even for fork PRs.
+# DO NOT add actions/checkout here referencing the PR head (github.event.pull_request.head.sha)
+# or otherwise execute untrusted PR code — doing so would let contributors exfiltrate secrets.
 on:
   issue_comment:
     types: [created]
   pull_request_target:
     types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
 
 jobs:
   CLAssistant:

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -10,7 +10,6 @@ on:
     types: [opened, closed, synchronize]
 
 permissions:
-  actions: write
   contents: read
   pull-requests: write
   statuses: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,5 +16,7 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,15 +6,20 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Import environment variables from file
-      run: cat ".github/env" >> $GITHUB_ENV
+      run: grep '^golang-version=' .github/env >> "$GITHUB_ENV"
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -13,8 +16,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Import environment variables from file
-        run: cat ".github/env" >> $GITHUB_ENV
+        run: grep '^golang-version=' .github/env >> "$GITHUB_ENV"
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -23,7 +27,7 @@ jobs:
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Copywrite
         uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3

--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: spelling
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     if: (success() || failure()) && needs.spelling.outputs.followup
     steps:


### PR DESCRIPTION
- Declare least-privilege top-level permissions on go.yml, goreleaser.yml, and cla.yaml so they no longer inherit the repo/org default token scope.
- Scope the cla.yaml token to actions/pull-requests/statuses write only (signatures are stored in a separate repo via PERSONAL_ACCESS_TOKEN), and add a SECURITY comment warning against checking out untrusted PR code in this pull_request_target workflow.
- Replace `cat .github/env >> $GITHUB_ENV` with a grep for the single expected key to prevent a fork PR from injecting arbitrary environment variables into the runner.
- Pin goreleaser to "~> v2" instead of `latest` for reproducible releases.
- Add persist-credentials: false to every actions/checkout so the git credential helper does not keep GITHUB_TOKEN on disk after checkout.
- Drop the spell-check comment job down to contents: read; it only needs pull-requests: write to post follow-ups.