### PR TITLE
fix: do not hide non-proto errors from response

### DIFF
--- a/client.go
+++ b/client.go
@@ -114,18 +114,29 @@ func (c *Client) DoClientRequest(ctx context.Context, client HTTPClient, url str
 	}
 
 	if resp.StatusCode != 200 {
-		// TODO wrap body in error
-		spb, err := parseStatus(resp.Body)
+		spb, payload, err := parseStatus(resp.Body)
+		// Only treat the body as a proto Status if it actually carries a non-OK
+		// code. An empty or otherwise degenerate body unmarshals without error
+		// into an OK-coded Status whose .Err() is nil, which would silently turn
+		// a non-200 response into a success with an unpopulated output message.
 		if err == nil {
-			log.Debug().Str("body", spb.Message).Int("status", resp.StatusCode).Msg("non-ok http request")
-			return status.FromProto(spb).Err()
-		} else {
-			payload, err := io.ReadAll(reader)
-			if err != nil {
-				log.Error().Err(err).Msg("could not parse http body")
+			if statusErr := status.FromProto(spb).Err(); statusErr != nil {
+				log.Debug().Str("body", spb.Message).Int("status", resp.StatusCode).Msg("non-ok http request")
+				return statusErr
 			}
-			return status.New(status.CodeFromHTTPStatus(resp.StatusCode), string(payload)).Err()
 		}
+		// The body is not a usable proto Status. This typically happens when an
+		// intermediary (load balancer, ingress, proxy) returns an HTML or
+		// plain-text error page — or an empty body — for a 5xx/429. Surface the
+		// body as the error message instead of dropping it, falling back to the
+		// HTTP status line when the body is empty, so the failure is diagnosable
+		// rather than an empty "code = Unknown desc = ".
+		msg := string(payload)
+		if msg == "" {
+			msg = resp.Status
+		}
+		log.Debug().Str("body", msg).Int("status", resp.StatusCode).Msg("non-ok http request with non-proto body")
+		return status.New(status.CodeFromHTTPStatus(resp.StatusCode), msg).Err()
 	}
 
 	if err = ctx.Err(); err != nil {

--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
@@ -50,6 +51,12 @@ type vtprotoMessage interface {
 	MarshalVT() ([]byte, error)
 	UnmarshalVT([]byte) error
 }
+
+// maxErrorBodySize bounds how many bytes of a non-proto error response body we
+// surface in the returned error message. Intermediaries (load balancers,
+// ingresses, proxies) can return large HTML error pages; without a cap those
+// would become multi-KB error strings.
+const maxErrorBodySize = 2 << 10 // 2 KiB
 
 // DoClientRequest makes a request to the Ranger service.
 // It will marshal the proto.Message into the request body, do the request and then parse the response into the
@@ -134,6 +141,11 @@ func (c *Client) DoClientRequest(ctx context.Context, client HTTPClient, url str
 		msg := string(payload)
 		if msg == "" {
 			msg = resp.Status
+		} else if len(msg) > maxErrorBodySize {
+			// Cap large error pages (e.g. HTML from an intermediary) so we do
+			// not return multi-KB error messages. ToValidUTF8 drops any partial
+			// rune left at the truncation boundary.
+			msg = strings.ToValidUTF8(msg[:maxErrorBodySize], "") + "... [truncated]"
 		}
 		log.Debug().Str("body", msg).Int("status", resp.StatusCode).Msg("non-ok http request with non-proto body")
 		return status.New(status.CodeFromHTTPStatus(resp.StatusCode), msg).Err()

--- a/client_test.go
+++ b/client_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -156,4 +157,35 @@ func TestDoClientRequestProtoStatusError(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.PermissionDenied, st.Code(), "the code must come from the proto Status body")
 	assert.Equal(t, msg, st.Message(), "the message must come from the proto Status body, not the HTTP fallback")
+}
+
+// TestDoClientRequestLargeErrorBodyTruncated verifies that a large non-proto
+// error body (e.g. a big HTML error page from an intermediary) is capped rather
+// than surfaced in full, so the returned error message stays bounded.
+func TestDoClientRequestLargeErrorBodyTruncated(t *testing.T) {
+	// A body far larger than the cap, all valid UTF-8.
+	body := strings.Repeat("A", 64*1024)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := &ranger.Client{}
+	err := c.DoClientRequest(
+		context.Background(),
+		srv.Client(),
+		srv.URL,
+		&pingpong.PingRequest{},
+		&pingpong.PongReply{},
+	)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	// The message must be bounded well below the body size, and flagged as cut.
+	assert.Less(t, len(st.Message()), len(body), "the oversized body must not be surfaced in full")
+	assert.LessOrEqual(t, len(st.Message()), 4*1024, "the message must stay bounded")
+	assert.Contains(t, st.Message(), "[truncated]", "a truncated message should be marked as such")
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,159 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ranger_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ranger "go.mondoo.com/ranger-rpc"
+	"go.mondoo.com/ranger-rpc/codes"
+	"go.mondoo.com/ranger-rpc/examples/pingpong"
+	"go.mondoo.com/ranger-rpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestDoClientRequestHappyPath verifies the normal success flow: the request
+// proto is marshalled and sent, and a 200 response whose body is a valid
+// protobuf message is unmarshalled back into the output message. The server
+// echoes the request's Sender to prove the round trip end to end.
+func TestDoClientRequestHappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqBody, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var ping pingpong.PingRequest
+		require.NoError(t, proto.Unmarshal(reqBody, &ping))
+
+		respBody, err := proto.Marshal(&pingpong.PongReply{Message: "pong: " + ping.Sender})
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/protobuf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(respBody)
+	}))
+	defer srv.Close()
+
+	c := &ranger.Client{}
+	out := &pingpong.PongReply{}
+	err := c.DoClientRequest(
+		context.Background(),
+		srv.Client(),
+		srv.URL,
+		&pingpong.PingRequest{Sender: "ping"},
+		out,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "pong: ping", out.Message, "the response body must be unmarshalled into the output message")
+}
+
+// TestDoClientRequestNonProtoErrorBody reproduces the failure mode where an
+// intermediary in front of the API (load balancer / ingress / proxy) returns a
+// non-200 response whose body is NOT a protobuf google.rpc.Status — for example
+// an HTML or plain-text error page accompanying a 502 Bad Gateway.
+//
+// The client is supposed to fall back to using that raw body as the error
+// message. Before the fix it instead read the already-consumed *request* body
+// reader, so the message was always empty and the error surfaced as the
+// famously uninformative "rpc error: code = Unknown desc = " (empty
+// description).
+func TestDoClientRequestNonProtoErrorBody(t *testing.T) {
+	const body = "<html><head><title>502 Bad Gateway</title></head><body>upstream connect error</body></html>"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 502 is not in the reverse status map, so it maps to codes.Unknown,
+		// and an HTML body cannot be decoded as a proto Status.
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := &ranger.Client{}
+	err := c.DoClientRequest(
+		context.Background(),
+		srv.Client(),
+		srv.URL,
+		&pingpong.PingRequest{},
+		&pingpong.PongReply{},
+	)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unknown, st.Code(), "502 with a non-proto body maps to Unknown")
+	assert.NotEmpty(t, st.Message(), "the upstream error body must be surfaced, not dropped as an empty description")
+	assert.Contains(t, st.Message(), "502 Bad Gateway", "the description should carry the upstream error body")
+}
+
+// TestDoClientRequestEmptyErrorBody is the sibling case to
+// TestDoClientRequestNonProtoErrorBody: a non-200 response with an *empty*
+// body. An empty body unmarshals without error into an OK-coded proto Status,
+// so status.FromProto(...).Err() is nil. Without a guard this made
+// DoClientRequest silently return nil (success) for a failed request, leaving
+// the output message unpopulated. The client must instead surface a real error,
+// falling back to the HTTP status line since there is no body to report.
+func TestDoClientRequestEmptyErrorBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway) // 502 with no body
+	}))
+	defer srv.Close()
+
+	c := &ranger.Client{}
+	err := c.DoClientRequest(
+		context.Background(),
+		srv.Client(),
+		srv.URL,
+		&pingpong.PingRequest{},
+		&pingpong.PongReply{},
+	)
+
+	require.Error(t, err, "a non-200 with an empty body must not be swallowed as success")
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unknown, st.Code(), "502 maps to Unknown")
+	assert.NotEmpty(t, st.Message(), "an empty body should fall back to the HTTP status line, not an empty description")
+	assert.Contains(t, st.Message(), "502", "the HTTP status line should be surfaced when the body is empty")
+}
+
+// TestDoClientRequestProtoStatusError verifies the primary error path is
+// unchanged: a non-200 response whose body IS a valid protobuf
+// google.rpc.Status is decoded and returned with its original code and message,
+// not the HTTP-status-derived fallback. This is the case the earlier fix wraps
+// in a guard, so it must still work end to end.
+func TestDoClientRequestProtoStatusError(t *testing.T) {
+	const msg = "you shall not pass"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Build the body exactly as the server side does: marshal the proto
+		// Status carried by a status error.
+		body, err := proto.Marshal(status.New(codes.PermissionDenied, msg).Proto())
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/protobuf")
+		w.WriteHeader(http.StatusForbidden) // 403, consistent with PermissionDenied
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := &ranger.Client{}
+	err := c.DoClientRequest(
+		context.Background(),
+		srv.Client(),
+		srv.URL,
+		&pingpong.PingRequest{},
+		&pingpong.PongReply{},
+	)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.PermissionDenied, st.Code(), "the code must come from the proto Status body")
+	assert.Equal(t, msg, st.Message(), "the message must come from the proto Status body, not the HTTP fallback")
+}

--- a/error.go
+++ b/error.go
@@ -58,15 +58,18 @@ func HttpError(span trace.Span, w http.ResponseWriter, req *http.Request, err er
 }
 
 // parseStatus tries to parse the proto Status from the body of the response.
-func parseStatus(reader io.Reader) (*spb.Status, error) {
+// It also returns the raw payload it read so callers can fall back to using the
+// body as an error message when it is not a valid proto Status (e.g. an HTML or
+// plain-text error page from an intermediary load balancer or proxy).
+func parseStatus(reader io.Reader) (*spb.Status, []byte, error) {
 	payload, err := io.ReadAll(reader)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var status spb.Status
 	err = proto.Unmarshal(payload, &status)
 	if err != nil {
-		return nil, err
+		return nil, payload, err
 	}
-	return &status, nil
+	return &status, payload, nil
 }


### PR DESCRIPTION
A subtle bug here. The `reader` in this line of code was the request reader, not from the response body and it was also already read to completion so it was always empty.
```go
payload, err := io.ReadAll(reader)
```

Here, we use the response body correctly when returning the error message. Also added a few happy/error test cases mimicking a request/response.